### PR TITLE
Add GenericController to handle basic CRUD endpoints

### DIFF
--- a/RecordShop.Tests/Controllers/API/Generic/GenericControllerTests.cs
+++ b/RecordShop.Tests/Controllers/API/Generic/GenericControllerTests.cs
@@ -1,0 +1,35 @@
+﻿namespace RecordShop.Tests.Controllers.API.Generic
+{
+    public class GenericControllerTests
+    {
+        [Test()]
+        public void GetTest()
+        {
+            Assert.Fail();
+        }
+
+        [Test()]
+        public void GetByIdTest()
+        {
+            Assert.Fail();
+        }
+
+        [Test()]
+        public void PostTest()
+        {
+            Assert.Fail();
+        }
+
+        [Test()]
+        public void DeleteTest()
+        {
+            Assert.Fail();
+        }
+
+        [Test()]
+        public void PutTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/RecordShop.Tests/Controllers/API/Generic/GenericControllerTests.cs
+++ b/RecordShop.Tests/Controllers/API/Generic/GenericControllerTests.cs
@@ -23,6 +23,10 @@ namespace RecordShop.Tests.Controllers.API.Generic
         [Test]
         public void Get_ShouldCallAppropriateServiceMethod()
         {
+            // ARRANGE
+            var serviceResponse = new ServiceObjectResponse<List<MockEntity>>(ServiceResponseType.NotFound, "message", null);
+            _serviceMock.Setup(x => x.GetEntities()).Returns(() => serviceResponse);
+
             // ACT
             _controller.Get();
 
@@ -63,6 +67,10 @@ namespace RecordShop.Tests.Controllers.API.Generic
         [Test]
         public void GetById_ShouldCallAppropriateServiceMethod([Range(0,1)] int id)
         {
+            // ARRANGE
+            var serviceResponse = new ServiceObjectResponse<MockEntity>(ServiceResponseType.NotFound, "message", null);
+            _serviceMock.Setup(x => x.GetEntityById(id)).Returns(serviceResponse);
+
             // ACT
             _controller.GetById(id);
 
@@ -107,6 +115,8 @@ namespace RecordShop.Tests.Controllers.API.Generic
         {
             // ARRANGE
             var mockEntity = new MockEntity();
+            var serviceResponse = new ServiceObjectResponse<MockEntity>(ServiceResponseType.Success, null, mockEntity);
+            _serviceMock.Setup(x => x.InsertEntity(mockEntity)).Returns(serviceResponse);
 
             // ACT
             _controller.Post(mockEntity);
@@ -133,6 +143,10 @@ namespace RecordShop.Tests.Controllers.API.Generic
         [Test]
         public void Delete_ShouldCallAppropriateServiceMethod([Range(0, 1)] int id)
         {
+            // ARRANGE
+            var serviceResponse = new ServiceResponse(ServiceResponseType.NotFound, "message");
+            _serviceMock.Setup(x => x.DeleteEntityById(id)).Returns(serviceResponse);
+
             // ACT
             _controller.Delete(id);
 
@@ -176,7 +190,9 @@ namespace RecordShop.Tests.Controllers.API.Generic
         public void Put_ShouldCallAppropriateServiceMethod([Range(0, 1)] int id)
         {
             // ARRANGE
-            var mockEntity = new MockEntity();
+            var mockEntity = new MockEntity() { Id = id };
+            var serviceResponse = new ServiceResponse(ServiceResponseType.NotFound, "message");
+            _serviceMock.Setup(x => x.UpdateEntity(mockEntity)).Returns(serviceResponse);
 
             // ACT
             _controller.Put(id, mockEntity);

--- a/RecordShop.Tests/Controllers/API/Generic/GenericControllerTests.cs
+++ b/RecordShop.Tests/Controllers/API/Generic/GenericControllerTests.cs
@@ -1,35 +1,221 @@
-﻿namespace RecordShop.Tests.Controllers.API.Generic
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using RecordShop.Controllers.API.Generic;
+using RecordShop.Services.Generic;
+using RecordShop.Services.Response;
+using RecordShop.Tests.Utility;
+
+namespace RecordShop.Tests.Controllers.API.Generic
 {
     public class GenericControllerTests
     {
-        [Test()]
-        public void GetTest()
+        private Mock<IGenericService<MockEntity>> _serviceMock;
+        private GenericController<MockEntity> _controller;
+
+        [SetUp]
+        public void Init()
         {
-            Assert.Fail();
+            _serviceMock = new Mock<IGenericService<MockEntity>>();
+            _controller = new GenericController<MockEntity>(_serviceMock.Object);
         }
 
-        [Test()]
-        public void GetByIdTest()
+        [Test]
+        public void Get_ShouldCallAppropriateServiceMethod()
         {
-            Assert.Fail();
+            // ACT
+            _controller.Get();
+
+            // ASSERT
+            _serviceMock.Verify(x => x.GetEntities(), Times.Once);
         }
 
-        [Test()]
-        public void PostTest()
+        [Test]
+        public void Get_WhenNotFoundServiceResponse_ReturnsNotFoundWithMessage()
         {
-            Assert.Fail();
+            // ARRANGE
+            var serviceResponse = new ServiceObjectResponse<List<MockEntity>>(ServiceResponseType.NotFound, "message", null);
+            _serviceMock.Setup(x => x.GetEntities()).Returns(() => serviceResponse);
+
+            // ACT
+            var result = _controller.Get();
+
+            // ASSERT
+            var okResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+            okResult.Value.Should().Be(serviceResponse.Message);
         }
 
-        [Test()]
-        public void DeleteTest()
+        [Test]
+        public void Get_WhenSuccessServiceResponse_ReturnsOkObjectResult()
         {
-            Assert.Fail();
+            // ARRANGE
+            var mockEntities = new List<MockEntity>() { new MockEntity() };
+            var serviceResponse = new ServiceObjectResponse<List<MockEntity>>(ServiceResponseType.Success, null, mockEntities);
+            _serviceMock.Setup(x => x.GetEntities()).Returns(() => serviceResponse);
+
+            // ACT
+            var result = _controller.Get();
+
+            // ASSERT
+            result.Should().BeOfType<OkObjectResult>();
         }
 
-        [Test()]
-        public void PutTest()
+        [Test]
+        public void GetById_ShouldCallAppropriateServiceMethod([Range(0,1)] int id)
         {
-            Assert.Fail();
+            // ACT
+            _controller.GetById(id);
+
+            // ASSERT
+            _serviceMock.Verify(x => x.GetEntityById(id), Times.Once);
+        }
+
+        [Test]
+        public void GetById_WhenNotFoundServiceResponse_ReturnsNotFoundWithMessage()
+        {
+            // ARRANGE
+            int id = 1;
+            var serviceResponse = new ServiceObjectResponse<MockEntity>(ServiceResponseType.NotFound, "message", null);
+            _serviceMock.Setup(x => x.GetEntityById(id)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.GetById(id);
+
+            // ASSERT
+            var okResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+            okResult.Value.Should().Be(serviceResponse.Message);
+        }
+
+        [Test]
+        public void GetById_WhenSuccessServiceResponse_ReturnsOkObjectResult()
+        {
+            // ARRANGE
+            int id = 1;
+            var mockEntity = new MockEntity() { Id = id };
+            var serviceResponse = new ServiceObjectResponse<MockEntity>(ServiceResponseType.Success, null, mockEntity);
+            _serviceMock.Setup(x => x.GetEntityById(id)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.GetById(id);
+
+            // ASSERT
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Test]
+        public void Post_ShouldCallAppropriateServiceMethod()
+        {
+            // ARRANGE
+            var mockEntity = new MockEntity();
+
+            // ACT
+            _controller.Post(mockEntity);
+
+            // ASSERT
+            _serviceMock.Verify(x => x.InsertEntity(mockEntity), Times.Once);
+        }
+
+        [Test]
+        public void Post_WhenSuccessServiceResponse_ReturnsCreatedResult()
+        {
+            // ARRANGE
+            var mockEntity = new MockEntity();
+            var serviceResponse = new ServiceObjectResponse<MockEntity>(ServiceResponseType.Success, null, mockEntity);
+            _serviceMock.Setup(x => x.InsertEntity(mockEntity)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.Post(mockEntity);
+
+            // ASSERT
+            result.Should().BeOfType<CreatedResult>();
+        }
+
+        [Test]
+        public void Delete_ShouldCallAppropriateServiceMethod([Range(0, 1)] int id)
+        {
+            // ACT
+            _controller.Delete(id);
+
+            // ASSERT
+            _serviceMock.Verify(x => x.DeleteEntityById(id), Times.Once);
+        }
+
+        [Test]
+        public void Delete_WhenNotFoundServiceResponse_ReturnsNotFoundWithMessage()
+        {
+            // ARRANGE
+            int id = 1;
+            var serviceResponse = new ServiceResponse(ServiceResponseType.NotFound, "message");
+            _serviceMock.Setup(x => x.DeleteEntityById(id)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.Delete(id);
+
+            // ASSERT
+            var okResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+            okResult.Value.Should().Be(serviceResponse.Message);
+        }
+
+        [Test]
+        public void Delete_WhenSuccessServiceResponse_ReturnsNoContentResult()
+        {
+            // ARRANGE
+            int id = 1;
+            var serviceResponse = new ServiceResponse(ServiceResponseType.Success, null);
+            _serviceMock.Setup(x => x.DeleteEntityById(id)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.Delete(id);
+
+            // ASSERT
+            result.Should().BeOfType<NoContentResult>();
+        }
+
+
+        [Test]
+        public void Put_ShouldCallAppropriateServiceMethod([Range(0, 1)] int id)
+        {
+            // ARRANGE
+            var mockEntity = new MockEntity();
+
+            // ACT
+            _controller.Put(id, mockEntity);
+
+            // ASSERT
+            _serviceMock.Verify(x => x.UpdateEntity(mockEntity), Times.Once);
+        }
+
+        [Test]
+        public void Put_WhenNotFoundServiceResponse_ReturnsNotFoundWithMessage()
+        {
+            // ARRANGE
+            int id = 1;
+            var mockEntity = new MockEntity() { Id = id };
+            var serviceResponse = new ServiceResponse(ServiceResponseType.NotFound, "message");
+            _serviceMock.Setup(x => x.UpdateEntity(mockEntity)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.Put(id, mockEntity);
+
+            // ASSERT
+            var okResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+            okResult.Value.Should().Be(serviceResponse.Message);
+        }
+
+        [Test]
+        public void Put_WhenSuccessServiceResponse_ReturnsNoContentResult()
+        {
+            // ARRANGE
+            int id = 1;
+            var mockEntity = new MockEntity() { Id = id };
+            var serviceResponse = new ServiceResponse(ServiceResponseType.Success, null);
+            _serviceMock.Setup(x => x.UpdateEntity(mockEntity)).Returns(serviceResponse);
+
+            // ACT
+            var result = _controller.Put(id, mockEntity);
+
+            // ASSERT
+            result.Should().BeOfType<NoContentResult>();
         }
     }
 }

--- a/RecordShop.Tests/Services/Generic/GenericServiceTests.cs
+++ b/RecordShop.Tests/Services/Generic/GenericServiceTests.cs
@@ -5,6 +5,7 @@ using RecordShop.Repositories.Generic;
 using RecordShop.Services.Generic;
 using FluentAssertions;
 using RecordShop.Services.Response;
+using RecordShop.Tests.Utility;
 
 namespace RecordShop.Tests.Services.Generic
 {
@@ -270,10 +271,5 @@ namespace RecordShop.Tests.Services.Generic
             // ASSERT
             response.ResponseType.Should().Be(ServiceResponseType.NotFound);
         }   
-    }
-
-    public class MockEntity : IEntity
-    {
-        public int Id { get; set; }
     }
 }

--- a/RecordShop.Tests/Utility/MockEntity.cs
+++ b/RecordShop.Tests/Utility/MockEntity.cs
@@ -1,0 +1,9 @@
+﻿using RecordShop.Model;
+
+namespace RecordShop.Tests.Utility
+{
+    public class MockEntity : IEntity
+    {
+        public int Id { get; set; }
+    }
+}

--- a/RecordShop/Controllers/API/Generic/GenericController.cs
+++ b/RecordShop/Controllers/API/Generic/GenericController.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using RecordShop.Model;
+using RecordShop.Services.Generic;
+
+namespace RecordShop.Controllers.API.Generic
+{
+    public class GenericController<TEntity> : ControllerBase where TEntity : class, IEntity
+    {
+        private readonly IGenericService<TEntity> _genericService;
+
+        public GenericController(IGenericService<TEntity> genericService)
+        {
+            _genericService = genericService;
+        }
+
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return BadRequest();
+        }
+
+        [HttpGet("{id}")]
+        public IActionResult GetById(int id)
+        {
+            return BadRequest();
+        }
+
+        [HttpPost]
+        public IActionResult Post(Genre genre)
+        {
+            return BadRequest();
+        }
+
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            return BadRequest();
+        }
+
+        [HttpPut("{id}")]
+        public IActionResult Put(int id, Genre genre)
+        {
+            return BadRequest();
+        }
+    }
+}

--- a/RecordShop/Controllers/API/Generic/GenericController.cs
+++ b/RecordShop/Controllers/API/Generic/GenericController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using RecordShop.Model;
 using RecordShop.Services.Generic;
+using RecordShop.Services.Response;
 
 namespace RecordShop.Controllers.API.Generic
 {
@@ -16,31 +17,85 @@ namespace RecordShop.Controllers.API.Generic
         [HttpGet]
         public IActionResult Get()
         {
-            return BadRequest();
+            var result = _genericService.GetEntities();
+
+            switch (result.ResponseType)
+            {
+                case ServiceResponseType.NotFound:
+                    return NotFound(result.Message);
+                case ServiceResponseType.Success:
+                    return Ok(result.Value);
+                default:
+                    return BadRequest();
+            }
         }
 
         [HttpGet("{id}")]
         public IActionResult GetById(int id)
         {
-            return BadRequest();
+            var result = _genericService.GetEntityById(id); 
+
+            switch (result.ResponseType)
+            {
+                case ServiceResponseType.NotFound:
+                    return NotFound(result.Message);
+                case ServiceResponseType.Success:
+                    return Ok(result.Value);
+                default:
+                    return BadRequest();
+            }
         }
 
         [HttpPost]
         public IActionResult Post(TEntity entity)
         {
-            return BadRequest();
+            var result = _genericService.InsertEntity(entity);
+
+            switch (result.ResponseType)
+            {
+                case ServiceResponseType.Success:
+
+                    if (result.Value == null)
+                    {
+                        return Created();
+                    }
+
+                    return Created(result.Value.Id.ToString(), result.Value);
+                default:
+                    return BadRequest();
+            }
         }
 
         [HttpDelete("{id}")]
         public IActionResult Delete(int id)
         {
-            return BadRequest();
+            var result = _genericService.DeleteEntityById(id);
+
+            switch (result.ResponseType)
+            {
+                case ServiceResponseType.NotFound:
+                    return NotFound(result.Message);
+                case ServiceResponseType.Success:
+                    return NoContent();
+                default:
+                    return BadRequest();
+            }
         }
 
         [HttpPut("{id}")]
         public IActionResult Put(int id, TEntity entity)
         {
-            return BadRequest();
+            var result = _genericService.UpdateEntity(entity);
+
+            switch (result.ResponseType)
+            {
+                case ServiceResponseType.NotFound:
+                    return NotFound(result.Message);
+                case ServiceResponseType.Success:
+                    return NoContent();
+                default:
+                    return BadRequest();
+            }
         }
     }
 }

--- a/RecordShop/Controllers/API/Generic/GenericController.cs
+++ b/RecordShop/Controllers/API/Generic/GenericController.cs
@@ -26,7 +26,7 @@ namespace RecordShop.Controllers.API.Generic
         }
 
         [HttpPost]
-        public IActionResult Post(Genre genre)
+        public IActionResult Post(TEntity entity)
         {
             return BadRequest();
         }
@@ -38,7 +38,7 @@ namespace RecordShop.Controllers.API.Generic
         }
 
         [HttpPut("{id}")]
-        public IActionResult Put(int id, Genre genre)
+        public IActionResult Put(int id, TEntity entity)
         {
             return BadRequest();
         }

--- a/RecordShop/Repositories/Generic/GenericRepository.cs
+++ b/RecordShop/Repositories/Generic/GenericRepository.cs
@@ -1,5 +1,4 @@
-﻿
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using RecordShop.Model;
 
 namespace RecordShop.Repositories.Generic

--- a/RecordShop/Services/GenresService.cs
+++ b/RecordShop/Services/GenresService.cs
@@ -1,15 +1,14 @@
 ﻿using RecordShop.Model;
 using RecordShop.Repositories;
+using RecordShop.Repositories.Generic;
+using RecordShop.Services.Generic;
 
 namespace RecordShop.Services
 {
-    public class GenresService : IGenresService
+    public class GenresService : GenericService<Genre>, IGenresService
     {
-        private readonly IGenresRepository _genreRepository;
-
-        public GenresService(IGenresRepository genreRepository)
+        public GenresService(IGenericRepository<Genre> repository) : base(repository)
         {
-            _genreRepository = genreRepository;
         }
     }
 }

--- a/RecordShop/Services/IGenresService.cs
+++ b/RecordShop/Services/IGenresService.cs
@@ -1,6 +1,9 @@
-﻿namespace RecordShop.Services
+﻿using RecordShop.Model;
+using RecordShop.Services.Generic;
+
+namespace RecordShop.Services
 {
-    public interface IGenresService
+    public interface IGenresService : IGenericService<Genre>
     {
     }
 }

--- a/RecordShop/Services/IRecordsService.cs
+++ b/RecordShop/Services/IRecordsService.cs
@@ -1,6 +1,9 @@
-﻿namespace RecordShop.Services
+﻿using RecordShop.Model;
+using RecordShop.Services.Generic;
+
+namespace RecordShop.Services
 {
-    public interface IRecordsService
+    public interface IRecordsService : IGenericService<Record>
     {
     }
 }

--- a/RecordShop/Services/RecordsService.cs
+++ b/RecordShop/Services/RecordsService.cs
@@ -1,14 +1,14 @@
-﻿using RecordShop.Repositories;
+﻿using RecordShop.Model;
+using RecordShop.Repositories;
+using RecordShop.Repositories.Generic;
+using RecordShop.Services.Generic;
 
 namespace RecordShop.Services
 {
-    public class RecordsService : IRecordsService
+    public class RecordsService : GenericService<Record>, IRecordsService
     {
-        private readonly IRecordsRepository _recordRepository;
-
-        public RecordsService(IRecordsRepository recordRepository)
+        public RecordsService(IGenericRepository<Record> repository) : base(repository)
         {
-            _recordRepository = recordRepository;
         }
     }
 }


### PR DESCRIPTION
Add GenericController class, which is designed to be inherited by controller classes to provide generic CRUD endpoints, using IGenericService and IGenericRepository under the hood.