### PR TITLE
feat: Use GenericController in RecordsController and GenresController

### DIFF
--- a/RecordShop/Controllers/API/GenresController.cs
+++ b/RecordShop/Controllers/API/GenresController.cs
@@ -1,48 +1,15 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using RecordShop.Controllers.API.Generic;
 using RecordShop.Model;
 using RecordShop.Services;
+using RecordShop.Services.Generic;
 
 namespace RecordShop.Controllers.API
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class GenresController : ControllerBase
+    public class GenresController : GenericController<Genre>
     {
-        private readonly IGenresService _genreService;
-
-        public GenresController(IGenresService genreService)
-        {
-            _genreService = genreService;
-        }
-
-        [HttpGet]
-        public IActionResult GetGenres()
-        {
-            return BadRequest();
-        }
-
-        [HttpGet("{id}")]
-        public IActionResult GetGenreById(int id)
-        {
-            return BadRequest();
-        }
-
-        [HttpPost]
-        public IActionResult PostGenre(Genre genre)
-        {
-            return BadRequest();
-        }
-
-        [HttpDelete("{id}")]
-        public IActionResult DeleteGenreById(int id)
-        {
-            return BadRequest();
-        }
-
-        [HttpPut("{id}")]
-        public IActionResult PutGenre(int id,  Genre genre)
-        {
-            return BadRequest();
-        }
+        public GenresController(IGenresService genresService) : base(genresService) { }
     }
 }

--- a/RecordShop/Controllers/API/RecordsController.cs
+++ b/RecordShop/Controllers/API/RecordsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using RecordShop.Controllers.API.Generic;
 using RecordShop.Model;
 using RecordShop.Services;
 
@@ -7,43 +8,8 @@ namespace RecordShop.Controllers.API
 
     [ApiController]
     [Route("api/[controller]")]
-    public class RecordsController : ControllerBase
+    public class RecordsController : GenericController<Record>
     {
-        private readonly IRecordsService recordService;
-
-        public RecordsController(IRecordsService recordService)
-        {
-            this.recordService = recordService;
-        }
-
-        [HttpGet]
-        public IActionResult GetRecords()
-        {
-            return BadRequest();
-        }
-
-        [HttpGet("{id}")]
-        public IActionResult GetRecordById(int id)
-        {
-            return BadRequest();
-        }
-
-        [HttpPost]
-        public IActionResult PostRecord(Record record)
-        {
-            return BadRequest();
-        }
-
-        [HttpDelete("{id}")]
-        public IActionResult DeleteRecordById(int id)
-        {
-            return BadRequest();
-        }
-
-        [HttpPut("{id}")]
-        public IActionResult PutGenre(int id, Record record)
-        {
-            return BadRequest();
-        }
+        public RecordsController(IRecordsService recordsService) : base(recordsService) { }
     }
 }

--- a/RecordShop/Services/GenresService.cs
+++ b/RecordShop/Services/GenresService.cs
@@ -1,13 +1,12 @@
 ﻿using RecordShop.Model;
 using RecordShop.Repositories;
-using RecordShop.Repositories.Generic;
 using RecordShop.Services.Generic;
 
 namespace RecordShop.Services
 {
     public class GenresService : GenericService<Genre>, IGenresService
     {
-        public GenresService(IGenericRepository<Genre> repository) : base(repository)
+        public GenresService(IGenresRepository repository) : base(repository)
         {
         }
     }

--- a/RecordShop/Services/RecordsService.cs
+++ b/RecordShop/Services/RecordsService.cs
@@ -1,13 +1,12 @@
 ﻿using RecordShop.Model;
 using RecordShop.Repositories;
-using RecordShop.Repositories.Generic;
 using RecordShop.Services.Generic;
 
 namespace RecordShop.Services
 {
     public class RecordsService : GenericService<Record>, IRecordsService
     {
-        public RecordsService(IGenericRepository<Record> repository) : base(repository)
+        public RecordsService(IRecordsRepository repository) : base(repository)
         {
         }
     }


### PR DESCRIPTION
Extend the GenericController class for RecordsController and GenresController, hence implementing all CRUD endpoints. At the moment, this is limited as the current generic system does not allow for DTOs. This is to be fixed in the future.